### PR TITLE
architectures.py: Fix ppc64 qemuname

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -205,7 +205,7 @@ class Arch_ppc(Arch):
         Arch.__init__(self, name)
 
         self.defconfig_target = 'ppc64e_defconfig'
-        self.qemuname = 'ppc64le'
+        self.qemuname = 'ppc64'
         self.linuxname = 'powerpc'
         self.gccname = 'powerpc64le'
 


### PR DESCRIPTION
qemuname is the used by virtme to imply the name of the qemu-system binary. There is no qemu-system-ppc64le binary, only qemu-system-ppc64.